### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go build && go test"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub repo size](https://img.shields.io/github/repo-size/mentix02/lightning)
 [![GitHub license](https://img.shields.io/github/license/mentix02/lightning)](https://github.com/mentix02/lightning/blob/master/LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mentix02/lightning)](https://goreportcard.com/report/github.com/mentix02/lightning)
+[![Run on Repl.it](https://repl.it/badge/github/mentix02/lightning)](https://repl.it/github/mentix02/lightning)
 
 A **simple** & blazingly fast API server for The Medialist.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@mentix02/lightning).